### PR TITLE
feat: enable diffing feature in AI terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ This plugin **seamlessly integrates any command-line (CLI) AI coding agents** in
   closing Neovim. The *next* time you open an AI terminal (e.g., using
   `toggle("aider")`), the backup directory is *synced* with the current project
   state using `rsync`, effectively resetting the diff
-  base to the state *before* the sync. The `diff_changes()` command finds
+  base to the state *before* the sync. **Note:** This backup sync behavior and
+  the associated diff commands (`diff_changes`, `close_diff`) are controlled by
+  the `enable_diffing` configuration option (enabled by default). If you disable
+  it (`enable_diffing = false`), the backup sync will not run, and the diff
+  commands will not function as expected. The `diff_changes()` command finds
   differing files between the current project state and the *most recently
-  synced* backup. These differing files are then opened in Neovim's standard
+  synced* backup. These differing files are then
+  opened in Neovim's standard
   diff view across multiple tabs. You can use standard diff commands like
   `:diffget` and `:diffput` to
   manage changes (see `:help diff`). The `close_diff()` command closes these
@@ -83,6 +88,10 @@ require("ai-terminals").setup({
   },
   -- Set the default window position if none is specified (default: "float")
   default_position = "bottom", -- Example: Make terminals open at the bottom by default
+  -- Enable/disable the diffing feature (default: true)
+  -- When enabled, a backup sync runs on terminal entry, allowing `diff_changes` and `close_diff` to work.
+  -- Disabling this (`false`) skips the backup sync and prevents diff commands from functioning.
+  enable_diffing = false,
 })
 ```
 

--- a/lua/ai-terminals/config.lua
+++ b/lua/ai-terminals/config.lua
@@ -37,6 +37,7 @@ Config.config = {
 		right = { width = 0.5, height = 0.5 },
 	},
 	default_position = "float", -- Default position if none is specified in toggle/open/get
+	enable_diffing = true, -- Enable backup sync and diff commands. Disabling this prevents `diff_changes` and `close_diff` from working.
 }
 
 return Config

--- a/lua/ai-terminals/terminal.lua
+++ b/lua/ai-terminals/terminal.lua
@@ -221,8 +221,10 @@ function Term.register_autocmds(term)
 
 	local augroup = vim.api.nvim_create_augroup(Term.group_name, { clear = false }) -- Ensure group exists, don't clear existing unrelated autocommands
 
-	-- Call the sync function so it gets executed first time terminal is open
-	DiffLib.pre_sync_code_base()
+	if Config.config.enable_diffing then
+		-- Call the sync function so it gets executed first time terminal is open
+		DiffLib.pre_sync_code_base()
+	end
 
 	-- Autocommand to reload buffers when focus leaves this specific terminal buffer
 	vim.api.nvim_create_autocmd("BufLeave", {

--- a/lua/ai-terminals/terminal.lua
+++ b/lua/ai-terminals/terminal.lua
@@ -1,3 +1,4 @@
+local Config = require("ai-terminals.config")
 local DiffLib = require("ai-terminals.diff")
 local Term = {}
 
@@ -231,13 +232,15 @@ function Term.register_autocmds(term)
 		callback = Term.reload_changes,
 	})
 
-	-- Autocommand to run backup when entering this specific terminal window
-	vim.api.nvim_create_autocmd("BufWinEnter", {
-		group = augroup,
-		buffer = bufnr,
-		desc = "Run backup sync when entering AI terminal window " .. bufnr,
-		callback = DiffLib.pre_sync_code_base,
-	})
+	-- Autocommand to run backup when entering this specific terminal window (required for diffing)
+	if Config.config.enable_diffing then
+		vim.api.nvim_create_autocmd("BufWinEnter", {
+			group = augroup,
+			buffer = bufnr,
+			desc = "Run backup sync when entering AI terminal window " .. bufnr,
+			callback = DiffLib.pre_sync_code_base,
+		})
+	end
 
 	registered_buffers[bufnr] = true -- Mark as registered
 end


### PR DESCRIPTION
Fixes #3 
- Added configuration option to enable or disable the diffing feature.
- Updated README to reflect changes in backup sync behavior.
- Modified terminal.lua to conditionally run backup sync based on the enable_diffing setting.